### PR TITLE
Support for custom `external_indices` in `Mul`

### DIFF
--- a/albert/__init__.py
+++ b/albert/__init__.py
@@ -32,5 +32,3 @@ _default_sizes: dict[str | None, int] = {
     "k": 5,  # k-point
     None: 10,  # default
 }
-
-ALLOW_NON_EINSTEIN_NOTATION = 0

--- a/albert/qc/uhf.py
+++ b/albert/qc/uhf.py
@@ -285,7 +285,7 @@ def _amplitude_as_rhf(
     # Relabel the indices
     for i, amp in enumerate(amps):
         indices = tuple(index.copy(spin="r") for index in amp.external_indices)
-        amps[i] = amp.apply(
+        amps[i] = amp.map_indices(dict(zip(amp.external_indices, indices))).apply(
             lambda tensor: type_rhf(*indices, name=tensor.name),
             QTensor,  # noqa: B023
         )

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -83,9 +83,6 @@ def test_mul():
     tensor3 = Tensor(i, name="o")
     assert (tensor1 * tensor3).external_indices == (j,)
 
-    with pytest.raises(ValueError):
-        tensor3 * tensor3 * tensor1
-
     k = Index("k")
     tensor4 = Tensor(j, k, name="p")
     mul2 = Mul(tensor1, tensor4)

--- a/tests/test_spin.py
+++ b/tests/test_spin.py
@@ -33,7 +33,7 @@ def test_ghf_to_rhf():
     )
 
     expr_rhf = ghf_to_rhf(expr_ghf)  # All have no external indices
-    expr_rhf = canonicalise_indices(expr_rhf.expand().canonicalise()).collect()
+    expr_rhf = canonicalise_indices(expr_rhf.expand()).canonicalise().collect()
     assert expr_rhf == expr_rhf.canonicalise()
     assert repr(expr_rhf) == "(2 * v(i,a,j,b) * v(i,a,j,b)) + (-1 * v(i,a,j,b) * v(i,b,j,a))"
     assert all(i.spin == "r" for i in expr_rhf.internal_indices)


### PR DESCRIPTION
Adds basic support for specifying external indices in a `Mul` object. This removes the `ALLOW_NON_EINSTEIN_NOTATION` flag which is now implied. This PR does not yet add proper support for this feature in modules such as `albert.opt`, nor is it properly tested.