### PR TITLE
Improve graph functionality in `Base`

### DIFF
--- a/albert/base.py
+++ b/albert/base.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
     from albert.types import SerialisedField
 
 T = TypeVar("T", bound="Base")
-Tchild = TypeVar("Tchild", bound="Base")
 TypeOrFilter = Optional[type[T] | tuple[type[T], ...] | Callable[["Base"], bool]]
 
 

--- a/albert/canon.py
+++ b/albert/canon.py
@@ -41,9 +41,9 @@ def iter_equivalent_forms(expr: Base) -> Generator[Base, None, None]:
 
     @functools.lru_cache(maxsize=None)
     def _symmetry(node: Tensor) -> list[Base]:
-        if node._symmetry is None:
+        if node.symmetry is None:
             return [node]
-        return list(node._symmetry(node))
+        return list(node.symmetry(node))
 
     def _iter_variants(node: Base) -> Generator[Base, None, None]:
         if isinstance(node, Scalar):
@@ -52,8 +52,8 @@ def iter_equivalent_forms(expr: Base) -> Generator[Base, None, None]:
         if isinstance(node, Tensor):
             yield from _symmetry(node)
             return
-        assert node._children is not None
-        variants = [list(_iter_variants(child)) if child else [] for child in node._children]
+        assert node.children is not None
+        variants = [list(_iter_variants(child)) if child else [] for child in node.children]
         for combo in itertools.product(*variants):
             yield node.copy(*combo)
 
@@ -89,7 +89,7 @@ def canonicalise_exhaustive(
         def key(e: Base) -> SupportsDunderLT[Any]:
             """Key function for canonicalisation."""
             if isinstance(e, Algebraic):
-                return tuple(sorted(filter(lambda x: not isinstance(x, Scalar), e._children or [])))
+                return tuple(sorted(filter(lambda x: not isinstance(x, Scalar), e.children or [])))
             return e
 
     expr = min(_iter_equivalent_forms(expr), key=key)
@@ -114,7 +114,7 @@ def canonicalise_indices(
     """
     # Get the indices, grouped by category
     index_groups = defaultdict(set)
-    for leaf in expr.search_leaves(Tensor):  # type: ignore[type-abstract]
+    for leaf in expr.search(Tensor):
         for index in leaf.external_indices:
             index_groups[index.category].add(index)
             index_flip = index.spin_flip()

--- a/albert/code/base.py
+++ b/albert/code/base.py
@@ -328,7 +328,7 @@ class BaseCodeGenerator(ABC):
         done = set()
         args = []
         for expr in expressions:
-            for tensor in expr.rhs.search_leaves(Tensor):
+            for tensor in expr.rhs.search(Tensor):
                 if not self.ignore_argument(tensor) and tensor.name not in done:
                     args.append(tensor)
                     done.add(tensor.name)
@@ -371,7 +371,7 @@ class BaseCodeGenerator(ABC):
         last_appearance: dict[TensorInfo, int] = {}
         info_tensor_map: dict[TensorInfo, Tensor] = {}
         for i, expr in enumerate(expressions):
-            for tensor in expr.rhs.search_leaves(Tensor):
+            for tensor in expr.rhs.search(Tensor):
                 info = _tensor_info(tensor)
                 last_appearance[info] = i
                 info_tensor_map[info] = tensor

--- a/albert/code/einsum.py
+++ b/albert/code/einsum.py
@@ -295,8 +295,8 @@ class EinsumCodeGenerator(BaseCodeGenerator):
         expr = Expression(expr.lhs, expr.rhs.expand())  # guarantee Add[Mul[Tensor | Scalar]]
         for i, mul in enumerate(expr.rhs._children or []):
             # Separate the scalar and tensors
-            scalars = list(mul.search_leaves(Scalar))
-            tensors = list(mul.search_leaves(Tensor))
+            scalars = list(mul.search(Scalar))
+            tensors = list(mul.search(Tensor))
 
             # Get the indices
             lhs = [tensor.external_indices for tensor in tensors]

--- a/albert/index.py
+++ b/albert/index.py
@@ -83,8 +83,8 @@ class Index(Serialisable):
     @property
     def category(self) -> tuple[str, str]:
         """Get the category of the index, a compound of space and spin."""
-        space = self._space if self._space is not None else ""
-        spin = self._spin if self._spin is not None else ""
+        space = self.space if self.space is not None else ""
+        spin = self.spin if self.spin is not None else ""
         return (space, spin)
 
     def copy(
@@ -92,11 +92,11 @@ class Index(Serialisable):
     ) -> Index:
         """Return a copy of the object with some properties changed."""
         if name is None:
-            name = self._name
+            name = self.name
         if spin is None:
-            spin = self._spin
+            spin = self.spin
         if space is None:
-            space = self._space
+            space = self.space
         return Index(name, spin=spin, space=space)
 
     def spin_flip(self) -> Index:
@@ -114,11 +114,11 @@ class Index(Serialisable):
         """
         import sympy
 
-        name = self._name
-        if self._spin is not None:
-            name += f"{self._spin}"
-        if self._space is not None:
-            name += f"{self._space}"
+        name = self.name
+        if self.spin is not None:
+            name += f"{self.spin}"
+        if self.space is not None:
+            name += f"{self.space}"
 
         return sympy.Symbol(name)
 
@@ -147,9 +147,9 @@ class Index(Serialisable):
         return {
             "_type": self.__class__.__name__,
             "_module": self.__class__.__module__,
-            "name": self._name,
-            "spin": self._spin,
-            "space": self._space,
+            "name": self.name,
+            "spin": self.spin,
+            "space": self.space,
         }
 
     @classmethod
@@ -164,13 +164,13 @@ class Index(Serialisable):
     def _hashable_fields(self) -> Iterable[SerialisedField]:
         """Yield fields of the hashable representation."""
         yield self.__class__.__name__
-        yield self._space.lower() if self._space else ""
-        yield self._space.isupper() if self._space else False
-        yield self._spin if self._spin is not None else ""
-        yield self._name
+        yield self.space.lower() if self.space else ""
+        yield self.space.isupper() if self.space else False
+        yield self.spin if self.spin is not None else ""
+        yield self.name
 
     def __repr__(self) -> str:
         """Return a string representation of the object."""
-        if self._spin in ("a", "b"):
-            return f"{self._name}{_to_greek(self._spin)}"
-        return self._name
+        if self.spin in ("a", "b"):
+            return f"{self.name}{_to_greek(self.spin)}"
+        return self.name

--- a/albert/opt/_gristmill.py
+++ b/albert/opt/_gristmill.py
@@ -79,7 +79,7 @@ def optimise_gristmill(
     # Find all the indices in the expressions
     indices: set[Index] = set()
     for expr in exprs:
-        for node in expr.rhs.search_leaves(Tensor):
+        for node in expr.rhs.search(Tensor):
             indices.update(node.indices)
 
     # Set the indices
@@ -133,7 +133,7 @@ def optimise_gristmill(
         terms.append(dr.define(output_base, *ranges_lhs, rhs))
 
         # Record the permutations and symbols
-        tensors = [expr.lhs] + list(expr.rhs.search_leaves(Tensor))
+        tensors = [expr.lhs] + list(expr.rhs.search(Tensor))
         done = set()
         for tensor in tensors:
             base = tensor.as_sympy().base if tensor.rank else tensor.as_sympy()

--- a/albert/qc/spin.py
+++ b/albert/qc/spin.py
@@ -38,11 +38,11 @@ def ghf_to_uhf(
 
     # Loop over leaves of the expression tree
     new_exprs: dict[tuple[Index, ...], Base] = defaultdict(Scalar)
-    for mul in expr._children:
+    for mul in expr.children:
         # Split the leaves into those that are already unrestricted and those that are not
         scalars = []
         tensors = []
-        for leaf in mul._children:
+        for leaf in mul.children:
             if isinstance(leaf, Scalar):
                 scalars.append(leaf)
             else:
@@ -87,9 +87,9 @@ def uhf_to_rhf(expr: Base, canonicalise: bool = True) -> Base:
 
     # Loop over leaves of the expression tree
     new_expr: Base = Scalar(0)
-    for mul in expr._children:
+    for mul in expr.children:
         leaves: list[Base] = []
-        for leaf in mul._children:
+        for leaf in mul.children:
             if isinstance(leaf, Scalar):
                 leaves.append(leaf)
             else:

--- a/albert/symmetry.py
+++ b/albert/symmetry.py
@@ -41,7 +41,7 @@ class Permutation(Serialisable):
     @property
     def rank(self) -> int:
         """Get the rank."""
-        return len(self._permutation)
+        return len(self.permutation)
 
     def __call__(self, obj: Base) -> Base:
         """Apply the permutation to the object.
@@ -52,14 +52,14 @@ class Permutation(Serialisable):
         Returns:
             Permuted object.
         """
-        return obj.permute_indices(self._permutation) * self._sign
+        return obj.permute_indices(self.permutation) * self.sign
 
     def _hashable_fields(self) -> Iterable[SerialisedField]:
         """Yield fields of the hashable representation."""
         yield self.__class__.__name__
         yield self.rank
-        yield from self._permutation
-        yield self._sign
+        yield from self.permutation
+        yield self.sign
 
     def as_json(self) -> _PermutationJSON:
         """Return a JSON representation of the object.
@@ -70,8 +70,8 @@ class Permutation(Serialisable):
         return {
             "_type": self.__class__.__name__,
             "_module": self.__class__.__module__,
-            "permutation": self._permutation,
-            "sign": self._sign,
+            "permutation": self.permutation,
+            "sign": self.sign,
         }
 
     @classmethod
@@ -89,18 +89,18 @@ class Permutation(Serialisable):
         Returns:
             String representation.
         """
-        return f"{self.__class__.__name__}({self._permutation}, {self._sign})"
+        return f"{self.__class__.__name__}({self.permutation}, {self.sign})"
 
     def __add__(self, other: Permutation) -> Permutation:
         """Append permutations."""
-        perm = self._permutation + tuple(p + len(self._permutation) for p in other._permutation)
-        sign = self._sign * other._sign
+        perm = self.permutation + tuple(p + len(self.permutation) for p in other.permutation)
+        sign = self.sign * other.sign
         return Permutation(perm, sign)
 
     def __mul__(self, other: Permutation) -> Permutation:
         """Compose permutations."""
-        perm = tuple(self._permutation[p] for p in other._permutation)
-        sign = self._sign * other._sign
+        perm = tuple(self.permutation[p] for p in other.permutation)
+        sign = self.sign * other.sign
         return Permutation(perm, sign)
 
 
@@ -129,14 +129,14 @@ class Symmetry(Serialisable):
         Yields:
             Permuted objects.
         """
-        for permutation in self._permutations:
+        for permutation in self.permutations:
             yield permutation(obj)
 
     def _hashable_fields(self) -> Iterable[SerialisedField]:
         """Yield fields of the hashable representation."""
         yield self.__class__.__name__
-        yield len(self._permutations)
-        yield from self._permutations
+        yield len(self.permutations)
+        yield from self.permutations
 
     def as_json(self) -> _SymmetryJSON:
         """Return a JSON representation of the object.
@@ -147,7 +147,7 @@ class Symmetry(Serialisable):
         return {
             "_type": self.__class__.__name__,
             "_module": self.__class__.__module__,
-            "permutations": tuple(p.as_json() for p in self._permutations),
+            "permutations": tuple(p.as_json() for p in self.permutations),
         }
 
     @classmethod
@@ -165,15 +165,15 @@ class Symmetry(Serialisable):
         Returns:
             String representation.
         """
-        return f"{self.__class__.__name__}({', '.join(map(str, self._permutations))})"
+        return f"{self.__class__.__name__}({', '.join(map(str, self.permutations))})"
 
     def __add__(self, other: Symmetry) -> Symmetry:
         """Append permutations."""
-        return Symmetry(*(self._permutations + other._permutations))
+        return Symmetry(*(self.permutations + other.permutations))
 
     def __mul__(self, other: Symmetry) -> Symmetry:
         """Compose permutations."""
-        return Symmetry(*(p * q for p, q in zip(self._permutations, other._permutations)))
+        return Symmetry(*(p * q for p, q in zip(self.permutations, other.permutations)))
 
 
 def symmetric_group(*permutations: tuple[int, ...]) -> Symmetry:


### PR DESCRIPTION
- Improves the graph functions in `Base`, type filters now accept types or filter functions
- Tree traversal order now controlled by `Traversal` enum
- Removes `ExpandedAddLayer` and `ExpandedMulLayer`
- Fixes some type hints and unnecessary private variable access